### PR TITLE
updated chunk size

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,7 +8,8 @@ import CopyCode from "../components/copyCode";
 import * as H from "../styles/home.style.js";
 
 //break into 1 MB chunks for demo purposes
-const chunkSize = 1000000;
+//6MB for new api.video s3 storage
+const chunkSize = 6000000;
 
 export default function Home() {
   const inputRef = useRef(null);


### PR DESCRIPTION
new s3 storage format requires chunks >5 MB.  Changed to 6 MB,